### PR TITLE
Support for newer version of libftdi.

### DIFF
--- a/src/io_ftdi.c
+++ b/src/io_ftdi.c
@@ -11,6 +11,7 @@
 #define IO_OUTPUT (PORT_TCK|PORT_TDI|PORT_TMS)
 
 #define USE_ASYNC
+#define USE_LIBFTDI1
 
 #ifndef USE_ASYNC
 #define FTDI_MAX_WRITESIZE 256
@@ -83,6 +84,8 @@ int io_scan(const unsigned char *TMS, const unsigned char *TDI, unsigned char *T
 #ifndef USE_ASYNC
 #error no async
 	int r, t;
+#else 
+	void *vres;
 #endif
 	
 	if (bits > sizeof(buffer)/2)
@@ -138,12 +141,21 @@ int io_scan(const unsigned char *TMS, const unsigned char *TDI, unsigned char *T
 		r += t;
 	}
 #else
+#ifdef USE_LIBFTDI1
+	vres = ftdi_write_data_submit(&ftdi, buffer, bits * 2);
+	if (!vres)
+	{
+		fprintf(stderr, "ftdi_write_data_submit (%s)\n", ftdi_get_error_string(&ftdi));
+		return -1;
+	}
+#else
 	res = ftdi_write_data_async(&ftdi, buffer, bits * 2);
 	if (res < 0)
 	{
 		fprintf(stderr, "ftdi_write_data_async %d (%s)\n", res, ftdi_get_error_string(&ftdi));
 		return -1;
 	}
+#endif
 
 	i = 0;
 	


### PR DESCRIPTION
Function `ftdi_write_data_async` was replaced by `ftdi_write_data_submit` in libftdi 1.0 - http://developer.intra2net.com/mailarchive/html/libftdi-git/2012/msg00011.html

This pull request adds support for new libftdi versions (also called libftdi1).
