### PR TITLE
Add FT2232H support

### DIFF
--- a/src/io_ftdi.c
+++ b/src/io_ftdi.c
@@ -13,8 +13,11 @@
 #define PORT_TDI            0x02
 #define PORT_TDO            0x04
 #define PORT_TMS            0x08
-#define PORT_MISC           0x90
-#define IO_OUTPUT (PORT_MISC|PORT_TCK|PORT_TDI|PORT_TMS)
+#define PORT_MISC_C         0x90
+#define PORT_MISC_H         0x80 // Put ADBUS4 pin in High Z
+
+#define IO_OUTPUT_C (PORT_MISC_C|PORT_TCK|PORT_TDI|PORT_TMS)
+#define IO_OUTPUT_H (PORT_MISC_H|PORT_TCK|PORT_TDI|PORT_TMS)
 
 #define IO_DEFAULT_OUT     (0xe0)               /* Found to work best for some FTDI implementations */
 
@@ -67,7 +70,7 @@ void io_close(void);
 //
 // verbosity: 0 means no output, increase from 0 for more and more debugging output
 //
-int io_init(int vendor, int product, const char* serial, unsigned int index, unsigned int interface, unsigned long frequency, int verbosity)
+int io_init(int vendor, int product, const char* serial, unsigned int index, unsigned int interface, unsigned long frequency, int verbosity, int device)
 {
 	int res;
 	unsigned char buf[1];
@@ -131,7 +134,13 @@ int io_init(int vendor, int product, const char* serial, unsigned int index, uns
 	}
 
 	ftdi_set_bitmode(&ftdi, 0xFF, BITMODE_CBUS);
-	res = ftdi_set_bitmode(&ftdi, IO_OUTPUT, BITMODE_SYNCBB);
+
+	uint8_t io_output = IO_OUTPUT_C;
+
+	if (device == 1)
+		io_output = IO_OUTPUT_H;
+
+	res = ftdi_set_bitmode(&ftdi, io_output, BITMODE_SYNCBB);
 	
 	if (res < 0)
 	{

--- a/src/io_ftdi.h
+++ b/src/io_ftdi.h
@@ -1,4 +1,4 @@
 void io_close(void);
-int io_init(int vendor, int product, const char* serial, unsigned int index, unsigned int interface, unsigned long frequency, int verbosity);
+int io_init(int vendor, int product, const char* serial, unsigned int index, unsigned int interface, unsigned long frequency, int verbosity, int device);
 int io_scan(const unsigned char *TMS, const unsigned char *TDI, unsigned char *TDO, int bits);
 int io_set_period(unsigned int period);

--- a/src/xvcd.c
+++ b/src/xvcd.c
@@ -323,11 +323,12 @@ int main(int argc, char **argv)
 	int product = -1, vendor = -1, index = 0, interface = 0;
 	unsigned long frequency = 0;
 	char * serial = NULL;
+	int device = 0;
 	struct sockaddr_in address;
 	
 	opterr = 0;
 	
-	while ((c = getopt(argc, argv, "vV:P:S:I:i:p:f:")) != -1)
+	while ((c = getopt(argc, argv, "vV:P:S:I:i:p:f:D:")) != -1)
 		switch (c)
 		{
 		case 'p':
@@ -345,6 +346,16 @@ int main(int argc, char **argv)
 		case 'I':
 			index = strtoul(optarg, NULL, 0);
 			break;
+		case 'D':
+			if (strcmp(optarg, "FT2232C") == 0) {
+				device = 0;
+			} else if (strcmp(optarg, "FT2232H") == 0) {
+				device = 1;
+			} else {
+				fprintf(stderr, "device not supported.\n");
+				return 1;
+			}
+			break;
 		case 'i':
 			interface = strtoul(optarg, NULL, 0);
 			break;
@@ -356,7 +367,7 @@ int main(int argc, char **argv)
 			frequency = strtoul(optarg, NULL, 0);
 			break;
 		case '?':
-			fprintf(stderr, "usage: %s [-v] [-V vendor] [-P product] [-S serial] [-I index] [-i interface] [-f frequency] [-p port]\n\n", *argv);
+			fprintf(stderr, "usage: %s [-v] [-V vendor] [-P product] [-S serial] [-I index] [-i interface] [-f frequency] [-p port] [-D device]\n\n", *argv);
 			fprintf(stderr, "          -v: verbosity, increase verbosity by adding more v's\n");
 			fprintf(stderr, "          -V: vendor ID, use to select the desired FTDI device if multiple on host. (default = 0x0403)\n");
 			fprintf(stderr, "          -P: product ID, use to select the desired FTDI device if multiple on host. (default = 0x6010)\n");
@@ -366,6 +377,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "              and product IDs on host. Can be used instead of -S but -S is more definitive. (default = 0)\n");
 			fprintf(stderr, "          -i: interface, select which \'port\' on the selected device to use if multiple port device. (default = 0)\n");
 			fprintf(stderr, "          -f: frequency in Hz, force TCK frequency. If set to 0, set from settck commands sent by client. (default = 0)\n");
+			fprintf(stderr, "          -D: device ID, use to select FT chip. Can be: FT2232C ; FT2232H (default = FT2232C)\n");
 			fprintf(stderr, "          -p: TCP port, TCP port to listen for connections from client (default = %d)\n\n", port);
 			return 1;
 		}
@@ -373,9 +385,10 @@ int main(int argc, char **argv)
 	if (vlevel > 0) 
 	{
 		printf ("verbosity level is %d\n", vlevel);
+		printf("Device id: %d\n", device);
 	}
 
-	if (io_init(vendor, product, serial, index, interface, frequency, vlevel))
+	if (io_init(vendor, product, serial, index, interface, frequency, vlevel, device))
 	{
 		fprintf(stderr, "io_init failed\n");
 		return 1;


### PR DESCRIPTION
Add support for FT2232H chip (e.g. Digilent Nexys Video).

Previously, the code implicitly assumed an FT2232C. When connecting to an FT2232H, extra GPIO pins (notably `ADBUS4`) were incorrectly configured as outputs, which held the FPGA in reset and caused Vivado error.

# Changes

- Added `-D` command-line option to select `FT2232C` or `FT2232H`.
- Adjusted `PORT_MISC` defaults so that ADBUS4 is not driven low by default, preventing unintended resets on FT2232H boards.